### PR TITLE
Fine tune issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: 🐛Bug Report
 description: File a bug report here
-title: "[BUG]: "
+title: ""
 labels:
   - bug
 #assignees:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: 🐛Bug Report
 description: File a bug report here
-title: ""
 labels:
   - bug
 #assignees:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: ✨Feature Request
 description: Request a new feature or enhancement
-title: ""
 labels:
   - feature
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,8 +1,8 @@
 name: ✨Feature Request
 description: Request a new feature or enhancement
-title: "[FEAT]: "
+title: ""
 labels:
-  - enhancement
+  - feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# 📑 Description

This PR aims to Remove the default title for both Issues Templates.
In my opinion labels should be used instead.

I went ahead and changed the label for feature requests because there is a label named "feature" and I think it suits it better.